### PR TITLE
Fix the python@2.rb formula. Probably.

### DIFF
--- a/Formula/python@2.rb
+++ b/Formula/python@2.rb
@@ -13,7 +13,7 @@ class PythonAT2 < Formula
   head "https://github.com/python/cpython.git", branch: "2.7"
 
   bottle do
-    root_url "https://github.com/yogieric/homebrew-test2/releases/download/python@2-2.7.17_1"
+    root_url "https://github.com/Khan/homebrew-repo/releases/download/python@2-2.7.17_1"
     sha256 catalina:     "98b2338e594c10f12feb7174710471591f786d42de7da989c235dc49df654f14"
     sha256 x86_64_linux: "95d8051734d511b62edece78371835a94c71446a6ff05b48b0ced85e87830308"
   end


### PR DESCRIPTION
## Summary:
The python@2.rb formula currently lists the origin for the bottle as being:
> root_url "https://github.com/yogieric/homebrew-test2/releases/download/python@2-2.7.17_1"
Today is Eric's last day, and we cannot depend on the repository existing long term. Indeed, we shouldn't have depended on it thus far, it must have sidestepped notice when we were setting this all up. It looks like this may work just by pointing the root_url back to this repository, as the same (we think) resource seems to exist here.

Most initial testing suggests this may or may not work. Either way, it's wrong as it currently is, so needs to be fixed or removed. This PR is the first step in addressing that.

If this doesn't work, we'll need to figure out if we can reliably use pyenv (most likely fix) or re-bottle the python2 binaries somehow.

Issue: XXX-XXXX

## Test plan:
1. Cross fingers! I was able to test this (sort of) locally, but it may not work the same when pushed to the master/main branch
2. Ideally, we just go through a normal install and rather than complaining the source doesnt exist, it just works